### PR TITLE
require lodash modules using their lowercase names

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,9 +3,9 @@
  * @type {exports}
  */
 
-var isArray = require('lodash.isArray');
-var isEmpty = require('lodash.isEmpty');
-var isString = require('lodash.isString');
+var isArray = require('lodash.isarray');
+var isEmpty = require('lodash.isempty');
+var isString = require('lodash.isstring');
 
 
 var makeNestedDescribe = function(pathBits, describeFn) {


### PR DESCRIPTION
In order to support linux, the names in the `require` expression must be lowercase.
See here: https://github.com/npm/npm/issues/3914